### PR TITLE
setup.py: entry_points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='myegg',
           'argparse',
       ],
       entry_points={
-          'console_scripts': ['myegg=myegg.command_line:main'],
+          'gui_scripts': ['myegg=myegg.command_line:main'],
       },
       include_package_data=True,
       zip_safe=False)


### PR DESCRIPTION
I think gui_scripts is better than command_scripts. There is no risk for this change. If not available, it changes back to command_scripts itself.